### PR TITLE
Shopping cart sessions

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,9 +15,11 @@
         "@types/helmet": "^4.0.0",
         "@types/morgan": "^1.9.4",
         "@types/node": "^18.15.11",
+        "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
+        "express-session": "^1.17.3",
         "helmet": "^6.0.1",
         "morgan": "^1.10.0"
       },
@@ -1120,6 +1122,26 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -2006,6 +2028,32 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-session": {
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.3.tgz",
+      "integrity": "sha512-4+otWXlShYlG1Ma+2Jnn+xgKUZTMJ5QD3YvfilX3AcocOAbIkVylSWEklzALe/+Pu4qV6TYBj5GwOBFfdKqLBw==",
+      "dependencies": {
+        "cookie": "0.4.2",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3475,6 +3523,14 @@
         }
       ]
     },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -4061,6 +4117,17 @@
       },
       "engines": {
         "node": ">=12.20"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/unbox-primitive": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,9 +19,11 @@
     "@types/helmet": "^4.0.0",
     "@types/morgan": "^1.9.4",
     "@types/node": "^18.15.11",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
+    "express-session": "^1.17.3",
     "helmet": "^6.0.1",
     "morgan": "^1.10.0"
   },

--- a/backend/src/api/api.ts
+++ b/backend/src/api/api.ts
@@ -76,4 +76,15 @@ router.get('/cart', (req: SessionRequest, res: Response): void => {
   res.send(JSON.stringify(req.session.shoppingCart));
 })
 
+router.get('/sessions', (req:any, res) => {
+  req.sessionStore.all((err, sessions) => {
+    if (err) {
+      console.error(err);
+      return res.status(500).send('Error getting sessions');
+    }
+    console.log(sessions);
+    res.send('Sessions logged to console');
+  });
+});
+
 export default router;

--- a/backend/src/api/api.ts
+++ b/backend/src/api/api.ts
@@ -2,30 +2,38 @@ import express from 'express';
 import { Request, Response } from 'express';
 import { PrismaClient } from '@prisma/client';
 
+interface SessionRequest extends Request {
+  session: any; // replace `any` with the type definition of your session object
+}
+
 const prisma = new PrismaClient();
 const router = express.Router();
 
 // get 10 products paginated with cursor
-router.get('/products', async (req: Request, res: Response): Promise<void> => {
-  const cursor = req.query.cursor as string | undefined;
-  const take = 10;
+router.get(
+  '/products',
+  async (req: SessionRequest, res: Response): Promise<void> => {
 
-  const products = await prisma.products.findMany({
-    take,
-    skip: cursor ? 1 : 0,
-    cursor: cursor ? { uuid: cursor } : undefined,
-  });
+    const cursor = req.query.cursor as string | undefined;
+    const take = 10;
 
-  const hasNextPage = await prisma.products.count({
-    where: {
-      uuid: { gt: products[products.length - 1].uuid },
-    },
-  });
+    const products = await prisma.products.findMany({
+      take,
+      skip: cursor ? 1 : 0,
+      cursor: cursor ? { uuid: cursor } : undefined,
+    });
 
-  const nextCursor = hasNextPage ? products[products.length - 1].uuid : null;
+    const hasNextPage = await prisma.products.count({
+      where: {
+        uuid: { gt: products[products.length - 1].uuid },
+      },
+    });
 
-  res.json({ products, cursor: nextCursor });
-});
+    const nextCursor = hasNextPage ? products[products.length - 1].uuid : null;
+
+    res.json({ products, cursor: nextCursor });
+  }
+);
 
 // get array of all product uuids
 router.get(
@@ -52,7 +60,7 @@ router.get(
         uuid: productId,
       },
     });
-    res.send(productData)
+    res.send(productData);
   }
 );
 

--- a/backend/src/api/api.ts
+++ b/backend/src/api/api.ts
@@ -64,4 +64,16 @@ router.get(
   }
 );
 
+router.post('/shopping-cart-session-update', (req: SessionRequest, res: Response): void => {
+  req.session.shoppingCart = req.body;
+  res.send(JSON.stringify('ok from shopping-cart'));
+})
+
+router.get('/cart', (req: SessionRequest, res: Response): void => {
+  if (!req.session.shoppingCart) {
+    req.session.shoppingCart = [];
+  }
+  res.send(JSON.stringify(req.session.shoppingCart));
+})
+
 export default router;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,4 +1,6 @@
 import express from 'express';
+import session from 'express-session';
+import cookieParser from 'cookie-parser';
 import morgan from 'morgan';
 import helmet from 'helmet';
 import cors from 'cors';
@@ -12,12 +14,25 @@ dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 // create the express app
 const app = express();
 
+// set up session the session
+app.use(
+  session({
+    name: 'thriftio-session',
+    secret: process.env.SESSION_SECRET,
+    resave: false,
+    saveUninitialized: true,
+    cookie: { httpOnly: true, sameSite: false },
+  })
+);
+
 // HTTP request logger
 app.use(morgan('dev'));
 // HTTP header security
 app.use(helmet());
 // Cross-origin resource sharing
 app.use(cors());
+// Cookie parser
+app.use(cookieParser());
 // use the api router
 app.use('/api', api);
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -30,7 +30,12 @@ app.use(morgan('dev'));
 // HTTP header security
 app.use(helmet());
 // Cross-origin resource sharing
-app.use(cors());
+app.use(
+  cors({
+    origin: process.env.CORS_ORIGIN,
+    credentials: true,
+  })
+);
 // Cookie parser
 app.use(cookieParser());
 // use the api router

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -14,30 +14,33 @@ dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 // create the express app
 const app = express();
 
-// set up session the session
+// HTTP request logger
+app.use(morgan('dev'));
+// HTTP header security
+app.use(helmet());
+// body parser
+app.use(express.json());
+// Cookie parser
+app.use(cookieParser());
+// Cross-origin resource sharing
+app.use(
+  cors({
+    origin: process.env.CORS_ORIGIN,
+    methods: ['POST', 'PUT', 'GET', 'OPTIONS', 'HEAD'],
+    credentials: true,
+  })
+);
+// set up session the application session
 app.use(
   session({
     name: 'thriftio-session',
     secret: process.env.SESSION_SECRET,
     resave: false,
-    saveUninitialized: true,
-    cookie: { httpOnly: true, sameSite: false },
+    saveUninitialized: false,
+    cookie: { maxAge: 1000 * 60 * 60, sameSite: false, secure: false },
   })
 );
 
-// HTTP request logger
-app.use(morgan('dev'));
-// HTTP header security
-app.use(helmet());
-// Cross-origin resource sharing
-app.use(
-  cors({
-    origin: process.env.CORS_ORIGIN,
-    credentials: true,
-  })
-);
-// Cookie parser
-app.use(cookieParser());
 // use the api router
 app.use('/api', api);
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -5,6 +5,14 @@ const nextConfig = {
     domains: ['m.media-amazon.com'],
   },
   reactStrictMode: false,
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: 'http://localhost:3000:path*',
+      },
+    ]
+  },
 }
 
 module.exports = nextConfig

--- a/frontend/src/components/cart/Cart/Cart.tsx
+++ b/frontend/src/components/cart/Cart/Cart.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react'
+import { useContext, useEffect } from 'react'
 import styles from './cart.module.scss'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -6,18 +6,39 @@ import shoppingCartIcon from '../../../../public/icons/shopping-cart.svg'
 import { ShoppingCartContext } from '@/context/ShoppingCartContext'
 
 function Cart() {
-  const { state } = useContext(ShoppingCartContext)
-  const { cart } = state
-  const numberOfItemsInCart = cart.length
+  const { state, dispatch } = useContext(ShoppingCartContext)
+
+  // create a use effect that runs once on mount and dispatches the action to get the cart from the server
+  useEffect(() => {
+    // check if shopping cart session is on server
+    async function checkForCart() {
+      const response = await fetch('/api/shopping-cart/get-session-cart', {
+        method: 'GET',
+        credentials: 'include',
+      })
+      const shoppingCart = await response.json()
+
+      if (shoppingCart) {
+        dispatch({
+          type: 'GET_CART',
+          payload: { shoppingCart },
+        })
+      }
+    }
+    checkForCart()
+  }, [])
+
+  const { shoppingCart } = state
+  const numberOfItemsInCart = shoppingCart.length
 
   return (
     <>
       <Link href="/carts/cart">
-      <Image
-        src={shoppingCartIcon}
-        alt="Shopping cart icon"
-        className={styles.shoppingCartIcon}
-      />
+        <Image
+          src={shoppingCartIcon}
+          alt="Shopping cart icon"
+          className={styles.shoppingCartIcon}
+        />
       </Link>
       <span className={styles.shoppingCartNumber}>{numberOfItemsInCart}</span>
       <span className={styles.shoppingCartLabel}>cart</span>

--- a/frontend/src/components/products/ProductCard/ProductCard.tsx
+++ b/frontend/src/components/products/ProductCard/ProductCard.tsx
@@ -10,7 +10,7 @@ interface ProductCardProps {}
 const ProductCard = forwardRef(
   ({ productData }: ProductCardProps, ref): JSX.Element => {
     // shpping cart context
-    const { state, dispatch } = useContext(ShoppingCartContext)
+    const { dispatch } = useContext(ShoppingCartContext)
 
     function handleClickAddToCart() {
       dispatch({

--- a/frontend/src/components/products/ProductsInfinitScroll/ProductsInfinitScroll.tsx
+++ b/frontend/src/components/products/ProductsInfinitScroll/ProductsInfinitScroll.tsx
@@ -37,7 +37,10 @@ function ProductsInfinitScroll(): JSX.Element {
 
   // fetch products from the API
   async function fetchProducts(cursor: string | null = null) {
-    const response = await fetch(`/api/products/paginatedProducts?cursor=${cursor}`)
+    const response = await fetch(`/api/products/paginatedProducts?cursor=${cursor}`,{
+      method: 'GET',
+      credentials: 'include',
+    })
     const productsData = await response.json()
     setProducts((prevProducts) => [...prevProducts, ...productsData.products])
     setPaginationCursor(productsData.cursor)

--- a/frontend/src/context/ShoppingCartContext.tsx
+++ b/frontend/src/context/ShoppingCartContext.tsx
@@ -11,7 +11,7 @@ interface Action {
 }
 
 interface State {
-  cart: Product[]
+  shoppingCart: Product[] | []
 }
 
 interface ShoppingCartContextType {
@@ -21,24 +21,39 @@ interface ShoppingCartContextType {
 
 // create shopping cart context
 const ShoppingCartContext = createContext<ShoppingCartContextType>({
-  state: { cart: [] },
+  state: { shoppingCart: [] },
   dispatch: () => {},
 })
 
 // initialize state
 const initailState: State = {
-  cart: [],
+  shoppingCart: [],
+}
+
+// update shopping cart session on server
+async function updateCart(cart: Product[]) {
+  await fetch('/api/shopping-cart-session-update', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(cart),
+  })
 }
 
 function ShopingCartContextProvider({ children }: Props) {
   // create reducer
   const reducers = (state: State, action: Action) => {
+    let newCart = [...state.shoppingCart]
     switch (action.type) {
+      case 'GET_CART':
+        const { shoppingCart } = action.payload
+        newCart = [...shoppingCart]
+        return { ...state, shoppingCart: newCart }
       case 'ADD_TO_CART':
         const { productData } = action.payload
-        const { cart } = state
-        const newCart = [...cart, productData]
-        return { ...state, cart: newCart }
+        newCart = [...newCart, productData]
+        updateCart(newCart)
+        return { ...state, shoppingCart: newCart }
       default:
         return state
     }

--- a/frontend/src/pages/api/products/paginatedProducts.ts
+++ b/frontend/src/pages/api/products/paginatedProducts.ts
@@ -17,12 +17,9 @@ export default async function handler(
 
     // handle pagination if paginationCursor is null
     const { cursor: paginationCursor } = req.query
-    console.log('cursor', paginationCursor)
     if (paginationCursor === 'null' || paginationCursor === undefined) {
-      console.log('sending short url')
       productApiUrl = `http://localhost:3000/api/products`
     } else {
-      console.log('sending long url')
       productApiUrl = `http://localhost:3000/api/products?cursor=${paginationCursor}`
     }
 

--- a/frontend/src/pages/api/shopping-cart-session-update.ts
+++ b/frontend/src/pages/api/shopping-cart-session-update.ts
@@ -1,0 +1,50 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import cookie from 'cookie'
+
+// create a type for the error response
+type ErrorResponse = {
+  error: {
+    message: string
+  }
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  try {
+    console.log('line:17:', req.cookies)
+    // POST shopping cart data to Express API
+    const response = await fetch(
+      'http://localhost:3000/api/shopping-cart-session-update',
+      {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: req.headers.cookie ?? '',
+        },
+        body: JSON.stringify(req.body),
+      }
+    )
+
+    // get cookie header from the response
+    const setCookieHeader = response.headers.get('set-cookie')
+
+    // set the cookie on browser
+    // this cookie had to be set manually
+    // due to nextJS sever not forwording it to the browser
+    res.setHeader('Set-Cookie', setCookieHeader)
+    //
+    res.status(200).json({ message: 'Cookie set successfully' })
+    //
+  } catch (error: any) {
+    const errorResponse: ErrorResponse = {
+      error: {
+        message: error.message,
+      },
+    }
+    // if there is an error, return the error message
+    res.status(500).json(errorResponse)
+  }
+}

--- a/frontend/src/pages/api/shopping-cart/get-session-cart.ts
+++ b/frontend/src/pages/api/shopping-cart/get-session-cart.ts
@@ -12,25 +12,15 @@ export default async function handler(
   res: NextApiResponse
 ) {
   try {
-    console.log('line:17:', req.cookies)
-
-    const response = await fetch(
-      'http://localhost:3000/api/cart',
-      {
-        method: 'GET',
-        credentials: 'include',
-        headers: {
-          'Cookie': req.headers.cookie ?? '',
-        },
-      }
-    )
-
+    const response = await fetch('http://localhost:3000/api/cart', {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        Cookie: req.headers.cookie ?? '',
+      },
+    })
     const shoppingCartSessionData = await response.json()
-
-    console.log('line:32:', shoppingCartSessionData)
     res.send(JSON.stringify(shoppingCartSessionData))
-
-
   } catch (error: any) {
     const errorResponse: ErrorResponse = {
       error: {

--- a/frontend/src/pages/api/shopping-cart/get-session-cart.ts
+++ b/frontend/src/pages/api/shopping-cart/get-session-cart.ts
@@ -1,0 +1,43 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+// create a type for the error response
+type ErrorResponse = {
+  error: {
+    message: string
+  }
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  try {
+    console.log('line:17:', req.cookies)
+
+    const response = await fetch(
+      'http://localhost:3000/api/cart',
+      {
+        method: 'GET',
+        credentials: 'include',
+        headers: {
+          'Cookie': req.headers.cookie ?? '',
+        },
+      }
+    )
+
+    const shoppingCartSessionData = await response.json()
+
+    console.log('line:32:', shoppingCartSessionData)
+    res.send(JSON.stringify(shoppingCartSessionData))
+
+
+  } catch (error: any) {
+    const errorResponse: ErrorResponse = {
+      error: {
+        message: error.message,
+      },
+    }
+    // if there is an error, return the error message
+    res.status(500).json(errorResponse)
+  }
+}

--- a/frontend/src/pages/carts/cart.tsx
+++ b/frontend/src/pages/carts/cart.tsx
@@ -4,11 +4,11 @@ import {CartItems} from '@/components/cart/'
 
 function CartPage() { 
   const { state } = useContext(ShoppingCartContext)
-  const { cart } = state
+  const { shoppingCart } = state
 
   return (
     <div>
-      <CartItems cartItems={cart} />
+      <CartItems cartItems={shoppingCart} />
     </div>
   )
 }


### PR DESCRIPTION
This pull request adds express session handling of the users shopping cart to the application. This allows for any products added to the users cart to be persisted if they are/are not logged and choose to leave or refresh the page.

There where many difficulties with implementing this feature which were primarily based on passing the express session cookie to and from the web browser which I will outline below. 

In order to get the express session cookie from the express server to the nextJS server the cors policy on the server needed to be changed to allow cross origin request and credential passing. Once this was done I was able to get the cookie to the nextJS server, but was unable to get the cookie from the nextJs server to the browser. It was being blocked due to 2 cookie setting `sameSite=false` and `secure=false` I initially set these to false because the express sever is running on port 3000 and the nextJS server is running on port 3001 so sameSite=false made sense, but chrome will block cookies with this setting unless the secure flag is set to true which can only be done if the cross origin requests are being completed over HTTPS which they were not since I was developing on local host. So the work around to this was to create a proxy in the nextJS config for the express server which allowed me to set the sameSite flag to true and the cookie to be set on the browser for the express session.

The next issue I ran into was once the cookie was set on the browser getting NextJS to send it back to the express server. I was making to sure to make my fetch API calls with the credentials include flag, but this was still not sending the cookie. The solution to this was manually grabbing the cookie from the request header and setting it on the response header which resolved the issues and allowed the express server to deserialize the session cookie.